### PR TITLE
Added Apache Commons Net and Apache POI Maven dependencies

### DIFF
--- a/java3wsa/pom.xml
+++ b/java3wsa/pom.xml
@@ -34,7 +34,16 @@
          <artifactId>jackson-databind</artifactId>
          <version>2.13.0</version>
       </dependency>
-
+      <dependency>
+         <groupId>commons-net</groupId>
+         <artifactId>commons-net</artifactId>
+         <version>3.8.0</version> <!-- Use the latest version available -->
+      </dependency>
+      <dependency>
+         <groupId>org.apache.poi</groupId>
+         <artifactId>poi-ooxml</artifactId>
+         <version>5.2.2</version> <!-- Use the latest version available -->
+      </dependency>
    </dependencies>
 
 


### PR DESCRIPTION
- Included `commons-net` dependency in `pom.xml` for FTP operations support.
- Added `poi-ooxml` dependency to handle Microsoft Word documents.
- Ensured compatibility with current project setup.

These additions are in preparation for the upcoming features involving FTP communications and Word document processing.